### PR TITLE
Voorkom overschrijven

### DIFF
--- a/kn/leden/mongo.py
+++ b/kn/leden/mongo.py
@@ -23,11 +23,11 @@ def _id(obj):
     raise ValueError
 
 class SONWrapper(object):
-    def __init__(self, data, collection, parent=None, versioned=False):
+    def __init__(self, data, collection, parent=None, detect_race=False):
         self._data = data
         self._collection = collection
         self._parent = parent
-        self._versioned = versioned
+        self._detect_race = detect_race
     def delete(self):
         assert self._data['_id'] is not None
         # TODO check version
@@ -38,7 +38,7 @@ class SONWrapper(object):
     def save(self, update_fields=NotImplemented):
         if self._parent is None:
             if '_id' in self._data:
-                if self._versioned:
+                if self._detect_race:
                     self._data['_version'] += 1
                     result = self._collection.update({
                         '_id': self._data['_id'],
@@ -50,7 +50,7 @@ class SONWrapper(object):
                     self._collection.update({
                         '_id': self._data['_id']}, self._data)
             else:
-                if self._versioned:
+                if self._detect_race:
                     self._data['_version'] = 1
                 self._data['_id'] = self._collection.insert(
                         self._data)

--- a/kn/leden/mongo.py
+++ b/kn/leden/mongo.py
@@ -10,7 +10,7 @@ from django.conf import settings
 conn = pymongo.Connection(settings.MONGO_HOST)
 db = conn[settings.MONGO_DB]
 
-class MongoWrapperException(Exception):
+class RaceCondition(Exception):
     pass
 
 def _id(obj):
@@ -44,8 +44,7 @@ class SONWrapper(object):
                         '_id': self._data['_id'],
                         '_version': self._data['_version']-1}, self._data, w=1)
                     if result['n'] < 1:
-                        raise MongoWrapperException(
-                            'Could not save - version mismatch?')
+                        raise RaceCondition('Document was not saved')
                 else:
                     self._collection.update({
                         '_id': self._data['_id']}, self._data)

--- a/kn/leden/mongo.py
+++ b/kn/leden/mongo.py
@@ -24,6 +24,11 @@ def _id(obj):
 
 class SONWrapper(object):
     def __init__(self, data, collection, parent=None, detect_race=False):
+        '''
+            parent:      SONWrapper can be nested. This is the parent.
+            detect_race: Add a _version field which is incremented with each
+                         update to detect (and fail on) race conditions.
+        '''
         self._data = data
         self._collection = collection
         self._parent = parent

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -72,7 +72,7 @@ def event_by_id(__id):
 
 class Event(SONWrapper):
     def __init__(self, data):
-        super(Event, self).__init__(data, ecol, versioned=True)
+        super(Event, self).__init__(data, ecol, detect_race=True)
         self._subscriptions = {str(d['user']): Subscription(d, self)
                                for d in data.get('subscriptions', [])}
     name = son_property(('name',))

--- a/kn/subscriptions/entities.py
+++ b/kn/subscriptions/entities.py
@@ -15,6 +15,7 @@ ecol = db['events']
 # Example of an event
 # ------------------
 # { "_id" : ObjectId("55631d03ed25c3345751714a"),
+#   "_version" : 1,
 #   "name" : "loco-activiteit",
 #   "humanName" : "Activiteit van de LoCo",
 #   "date" : ISODate("2015-05-25T00:00:00Z"),
@@ -71,7 +72,7 @@ def event_by_id(__id):
 
 class Event(SONWrapper):
     def __init__(self, data):
-        super(Event, self).__init__(data, ecol)
+        super(Event, self).__init__(data, ecol, versioned=True)
         self._subscriptions = {str(d['user']): Subscription(d, self)
                                for d in data.get('subscriptions', [])}
     name = son_property(('name',))

--- a/utils/one-shot/2015-05-25-convert-subscriptions.py
+++ b/utils/one-shot/2015-05-25-convert-subscriptions.py
@@ -19,6 +19,8 @@ def main():
         print 'Event:', event.get('name')
         if not 'subscriptions' in event:
             event['subscriptions'] = []
+        if not '_version' in event:
+            event['_version'] = 1
         subscriptions = event['subscriptions']
         users = {s['user'] for s in subscriptions}
         for subscription in scol.find({'event': event['_id']}).sort('date'):


### PR DESCRIPTION
@bwesterb wat denk jij hiervan?
Op deze manier is hiet niet mogelijk dat er concurrency issues voorkomen (twee mensen schrijven zich tegelijkertijd in).
In de oude database kwam dit één keer voor en nu zit alles in hetzelfde object, dus het lijkt me wel nodig.
Een activiteit aanmaken, bewerken en aanmelden is getest.
